### PR TITLE
tools - Update Ping role in discord notice workflow

### DIFF
--- a/.github/workflows/discord-notice.yml
+++ b/.github/workflows/discord-notice.yml
@@ -15,7 +15,7 @@ jobs:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           username: "AWX - Release Bot"
           avatar_url: ""
-          content: "|| @AWX-Ping ||"
+          content: "<@&1433861483476942991>"
           footer_title: "AWX - ACE Wardrobe Extended "
           footer_icon_url: ""
           footer_timestamp: true


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- bin mir nicht 100% sicher warum es nicht ging, entweder das `||@` ohne Leerzeichen oder es hat ein problem mit dem leerzeichen der Rolle `@AWX Ping`. Deswegen mal beides geändert.

## IMPORTANT

- [ ] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [ ] Title of this PR describes the changes accurately.
- [ ] Mod is added to `readme.md`
- [ ] Launch Preset is added to `.hemmt/launch.toml`.
